### PR TITLE
Fix sorting for non-numeric JIDs

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -226,7 +226,11 @@ class ChatwootImport {
         const aMessageTimestamp = a.messageTimestamp as any as number;
         const bMessageTimestamp = b.messageTimestamp as any as number;
 
-        return parseInt(aKey.remoteJid) - parseInt(bKey.remoteJid) || aMessageTimestamp - bMessageTimestamp;
+        if (aKey.remoteJid === bKey.remoteJid) {
+          return aMessageTimestamp - bMessageTimestamp;
+        }
+
+        return aKey.remoteJid.localeCompare(bKey.remoteJid);
       });
 
       const allMessagesMappedByPhoneNumber = this.createMessagesMapByPhoneNumber(messagesOrdered);


### PR DESCRIPTION
## Summary
- ensure message ordering doesn't rely on numeric JIDs

## Testing
- `npm test` *(fails: tsnd not found)*
- `npm run lint:check` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f327b6e4c83278aa879fe3b403310