### PR TITLE
Fix chatwoot ignore for lid jids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.4 (2025-02-24)
+
+### Changed
+
+* Treat `@lid` JIDs as contacts in Chatwoot ignore checks
+
 # 2.2.3 (2025-02-03 11:52)
 
 ### Fixed

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1897,7 +1897,11 @@ export class ChatwootService {
           return;
         }
 
-        if (ignoreContacts && body?.key?.remoteJid.endsWith('@s.whatsapp.net')) {
+        if (
+          ignoreContacts &&
+          (body?.key?.remoteJid.endsWith('@s.whatsapp.net') ||
+            body?.key?.remoteJid.endsWith('@lid'))
+        ) {
           this.logger.warn('Ignoring message from contact: ' + body?.key?.remoteJid);
           return;
         }

--- a/src/api/integrations/chatbot/chatwoot/validate/chatwoot.schema.ts
+++ b/src/api/integrations/chatbot/chatwoot/validate/chatwoot.schema.ts
@@ -38,7 +38,12 @@ export const chatwootSchema: JSONSchema7 = {
     mergeBrazilContacts: { type: 'boolean', enum: [true, false] },
     importMessages: { type: 'boolean', enum: [true, false] },
     daysLimitImportMessages: { type: 'number' },
-    ignoreJids: { type: 'array', items: { type: 'string' } },
+    ignoreJids: {
+      type: 'array',
+      items: { type: 'string' },
+      description:
+        "List of JIDs to ignore. Use '@g.us' to skip all groups and '@s.whatsapp.net' to skip all contacts (including '@lid').",
+    },
   },
   required: ['enabled', 'accountId', 'token', 'url', 'signMsg', 'reopenConversation', 'conversationPending'],
   ...isNotEmpty('enabled', 'accountId', 'token', 'url', 'signMsg', 'reopenConversation', 'conversationPending'),


### PR DESCRIPTION
## Summary
- treat `@lid` remote JIDs like contacts when filtering messages
- document ignore list behaviour in chatwoot schema
- note change in changelog

## Testing
- `npm test` *(fails: tsnd not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f393753b08327bda2f08ed6dd6d65