### PR TITLE
Fix jid sort comparator

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -213,7 +213,7 @@ class ChatwootImport {
         return 0;
       }
 
-      // ordering messages by number and timestamp asc
+      // ordering messages by JID string and timestamp asc
       messagesOrdered.sort((a, b) => {
         const aKey = a.key as {
           remoteJid: string;
@@ -226,7 +226,8 @@ class ChatwootImport {
         const aMessageTimestamp = a.messageTimestamp as any as number;
         const bMessageTimestamp = b.messageTimestamp as any as number;
 
-        return parseInt(aKey.remoteJid) - parseInt(bKey.remoteJid) || aMessageTimestamp - bMessageTimestamp;
+        const jidCompare = aKey.remoteJid.localeCompare(bKey.remoteJid);
+        return jidCompare || aMessageTimestamp - bMessageTimestamp;
       });
 
       const allMessagesMappedByPhoneNumber = this.createMessagesMapByPhoneNumber(messagesOrdered);


### PR DESCRIPTION
## Summary
- use string comparison for JID sorting in chatwoot import
- revert earlier package and test changes

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_b_684f3942940083279cfc35428c2b268a