### PR TITLE
Fix Chatwoot contact phone check

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -315,10 +315,13 @@ export class ChatwootService {
       };
 
       const isLid = jid?.endsWith('@lid');
-      if ((jid && jid.includes('@') && !isLid) || !jid) {
-        data['phone_number'] = `+${phoneNumber}`;
-      } else if (isLid && phoneNumber && phoneNumber !== jid?.split('@')[0]) {
-        data['phone_number'] = `+${phoneNumber}`;
+
+      if (isLid) {
+        if (phoneNumber && phoneNumber !== jid?.split('@')[0]) {
+          data.phone_number = `+${phoneNumber}`;
+        }
+      } else if (phoneNumber) {
+        data.phone_number = `+${phoneNumber}`;
       }
     } else {
       data = {


### PR DESCRIPTION
## Summary
- update phone number logic in `createContact` so `@lid` senders only store real numbers

## Testing
- `npm run lint:check` *(fails: .eslintignore no longer supported)*
- `npm run build` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_b_684f456d604c8327b6eebcba2ee3edaa