### PR TITLE
Fix ignore check for @lid JIDs

### DIFF
--- a/src/api/integrations/chatbot/chatbot.controller.ts
+++ b/src/api/integrations/chatbot/chatbot.controller.ts
@@ -145,7 +145,10 @@ export class ChatbotController {
         return true;
       }
 
-      if (ignoreContacts && remoteJid.endsWith('@s.whatsapp.net')) {
+      if (
+        ignoreContacts &&
+        (remoteJid.endsWith('@s.whatsapp.net') || remoteJid.endsWith('@lid'))
+      ) {
         this.logger.warn('Ignoring message from contact: ' + remoteJid);
         return true;
       }


### PR DESCRIPTION
## Summary
- treat JIDs ending with `@lid` as contacts when checking ignored JIDs

## Testing
- `npm run lint`
- `npm test` *(fails: tsnd not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f5192aa748327b91b95b2bbd40cd0