### PR TITLE
Handle Linked ID contact creation

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -313,8 +313,17 @@ export class ChatwootService {
     // 2) montar payload
     const data: any = { inbox_id: inboxId, name: name || phoneNumber, avatar_url };
     if (!isGroup) {
-      data.identifier = jid;
-      data.phone_number = `+${phoneNumber}`;
+      const isLinkedId = jid?.endsWith('@lid');
+      if (isLinkedId && jid) {
+        data.identifier = jid;
+        this.logger.verbose(
+          `[ChatwootService][createContact] Linked ID detected for ${jid}; creating contact without phone number`
+        );
+      } else {
+        data.identifier = jid;
+        const isNumeric = /^\d+$/.test(phoneNumber);
+        data.phone_number = isNumeric ? `+${phoneNumber}` : phoneNumber;
+      }
     } else {
       data.identifier = phoneNumber;
     }


### PR DESCRIPTION
## Summary
- handle Linked ID numbers in Chatwoot contact creation
- only prefix a phone number with `+` when numeric
- log when contact is created using a Linked ID

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: tsnd not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f68bda06c8327b95ed6a51b52b9cb