### PR TITLE
Fix contact creation JID handling

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -730,8 +730,11 @@ export class ChatwootService {
   
     // 4) Contato
     const isGroup = remoteJid.includes("@g.us");
-    const chatId = isGroup ? remoteJid : remoteJid.split("@")[0];
-    this.logger.verbose("[_createConversation] isGroup=" + isGroup + ", chatId=" + chatId);
+    const isLinkedId = remoteJid.endsWith("@lid");
+    const chatId = isGroup || isLinkedId ? remoteJid : remoteJid.split("@")[0];
+    this.logger.verbose(
+      "[_createConversation] isGroup=" + isGroup + ", chatId=" + chatId
+    );
   
     let contact = await this.findContact(instance, chatId);
     if (contact) {
@@ -758,7 +761,7 @@ export class ChatwootService {
         isGroup,
         name,
         pictureUrl || null,
-        isGroup ? remoteJid : undefined
+        remoteJid
       );
       if (!contact) {
         this.logger.error("[_createConversation] Falha ao criar contato para " + chatId);


### PR DESCRIPTION
## Summary
- ensure remote JIDs ending with `@lid` keep the full JID when creating a conversation
- always pass `remoteJid` to `createContact` so the identifier is stored

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: tsnd not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f69857418832786fb3138ebe7beff