### PR TITLE
Update docs for Chatwoot @lid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 * Treat `@lid` JIDs as contacts in Chatwoot ignore checks
+* Chatwoot integration fully supports Linked IDs (`@lid`) for conversations and contacts.
 
 # 2.2.3 (2025-02-03 11:52)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Evolution API supports various integrations to enhance its functionality. Below 
 - [Chatwoot](https://www.chatwoot.com/):
   - Direct integration with Chatwoot for handling customer service for your business.
   - History import now supports Linked IDs, preserving JIDs ending in `@lid`.
+  - Chats and contacts with `@lid` identifiers are fully recognized. Example: `5511999999999@lid` remains linked when synced with Chatwoot.
 
 - [RabbitMQ](https://www.rabbitmq.com/):
   - Receive events from the Evolution API via RabbitMQ.


### PR DESCRIPTION
## Summary
- clarify Chatwoot `@lid` support in README
- note full `@lid` identifier support in CHANGELOG

## Testing
- `npm ci`
- `npm test` *(fails: Unable to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_b_684f6e60b0588327a9640c361f45ca6b