### PR TITLE
Extend JID suffix check

### DIFF
--- a/src/utils/createJid.ts
+++ b/src/utils/createJid.ts
@@ -35,7 +35,12 @@ function formatBRNumber(jid: string) {
 export function createJid(number: string): string {
   number = number.replace(/:\d+/, '');
 
-  if (number.includes('@g.us') || number.includes('@s.whatsapp.net') || number.includes('@lid')) {
+  if (
+    number.includes('@g.us') ||
+    number.includes('@s.whatsapp.net') ||
+    number.includes('@c.us') ||
+    number.includes('@lid')
+  ) {
     return number;
   }
 


### PR DESCRIPTION
## Summary
- early return JIDs that already use the `@c.us` suffix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850a309cd9c8327ad5a32244c249579