### PR TITLE
Fix TypeScript access on client contacts

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1176,7 +1176,7 @@ export class BaileysStartupService extends ChannelStartupService {
           if (original?.endsWith('@lid')) {
             this.logger.error({ original, received });
 
-            const numeric = this.client.contacts?.[original]?.id;
+            const numeric = (this.client as any).contacts?.[original]?.id;
 
             if (numeric && !numeric.endsWith('@lid')) {
               received.key.remoteJid = numeric;


### PR DESCRIPTION
## Summary
- handle Baileys client `contacts` field without type errors

## Testing
- `npm install --ignore-scripts`
- `npm run build` *(fails: Cannot find module 'baileys', PrismaRepository property errors)*

------
https://chatgpt.com/codex/tasks/task_b_6850a50fbf3c83279474acfc3e54421e