### PR TITLE
Fix Prisma update with messageRaw

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1405,9 +1405,12 @@ export class BaileysStartupService extends ChannelStartupService {
 
                   messageRaw.message.mediaUrl = mediaUrl;
 
+                  const dbData = { ...messageRaw } as any;
+                  delete dbData.originalJid;
+
                   await this.prismaRepository.message.update({
                     where: { id: msg.id },
-                    data: messageRaw,
+                    data: dbData,
                   });
                 } catch (error) {
                   this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);
@@ -2410,9 +2413,12 @@ export class BaileysStartupService extends ChannelStartupService {
 
             messageRaw.message.mediaUrl = mediaUrl;
 
+            const dbData = { ...messageRaw } as any;
+            delete dbData.originalJid;
+
             await this.prismaRepository.message.update({
               where: { id: msg.id },
-              data: messageRaw,
+              data: dbData,
             });
           } catch (error) {
             this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);


### PR DESCRIPTION
## Summary
- skip `originalJid` when updating a message after uploading media
- skip `originalJid` during S3 upload flow

## Testing
- `npm test` *(fails: tsnd not found)*
- `npm run lint:check` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6850b14e6d7083279977baf1618bbbb2