### PR TITLE
Serialize whatsappNumber

### DIFF
--- a/src/api/controllers/chat.controller.ts
+++ b/src/api/controllers/chat.controller.ts
@@ -19,11 +19,45 @@ import { Query } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
 import { Contact, Message, MessageUpdate } from '@prisma/client';
 
+class SimpleMutex {
+  private locked = false;
+  private waiting: Array<() => void> = [];
+
+  async acquire(): Promise<void> {
+    if (this.locked) {
+      await new Promise<void>((resolve) => this.waiting.push(resolve));
+    }
+    this.locked = true;
+  }
+
+  release(): void {
+    const next = this.waiting.shift();
+    if (next) {
+      next();
+    } else {
+      this.locked = false;
+    }
+  }
+
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}
+
 export class ChatController {
   constructor(private readonly waMonitor: WAMonitoringService) {}
 
+  private static whatsappNumberMutex = new SimpleMutex();
+
   public async whatsappNumber({ instanceName }: InstanceDto, data: WhatsAppNumberDto) {
-    return await this.waMonitor.waInstances[instanceName].whatsappNumber(data);
+    return await ChatController.whatsappNumberMutex.runExclusive(async () => {
+      return this.waMonitor.waInstances[instanceName].whatsappNumber(data);
+    });
   }
 
   public async readMessage({ instanceName }: InstanceDto, data: ReadMessageDto) {


### PR DESCRIPTION
## Summary
- add `SimpleMutex` helper
- add a static `whatsappNumberMutex` in chat controller
- ensure whatsappNumber requests run exclusively

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find config)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: tsnd not found)*

------
https://chatgpt.com/codex/tasks/task_b_687296a8056c832783ed42e11ecf6884