### PR TITLE
Handle missing S3 client and ignore unsupported policy

### DIFF
--- a/src/api/integrations/storage/s3/libs/minio.server.ts
+++ b/src/api/integrations/storage/s3/libs/minio.server.ts
@@ -40,19 +40,32 @@ const bucketExists = async () => {
 };
 
 const setBucketPolicy = async () => {
-  if (minioClient) {
-    const policy = {
-      Version: '2012-10-17',
-      Statement: [
-        {
-          Effect: 'Allow',
-          Principal: '*',
-          Action: ['s3:GetObject'],
-          Resource: [`arn:aws:s3:::${bucketName}/*`],
-        },
-      ],
-    };
+  if (!minioClient) return;
+
+  const policy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: '*',
+        Action: ['s3:GetObject'],
+        Resource: [`arn:aws:s3:::${bucketName}/*`],
+      },
+    ],
+  };
+
+  try {
     await minioClient.setBucketPolicy(bucketName, JSON.stringify(policy));
+    logger.info(`[S3 Service] Bucket policy applied on ${bucketName}`);
+  } catch (err: any) {
+    if (err.code === 'NotImplemented') {
+      logger.warn(
+        `[S3 Service] setBucketPolicy not supported by this endpoint, ignoring (bucket=${bucketName})`,
+      );
+    } else {
+      logger.error('[S3 Service] Error applying bucket policy', err);
+      throw err;
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- guard against missing S3 client in bucket policy logic
- log bucket policy application
- tolerate NotImplemented errors

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_6872971a57f083279637a5ab49044dbe