### PR TITLE
Improve Chatwoot import utilities

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -6,6 +6,7 @@ import { Chatwoot, configService } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import { inbox } from '@figuro/chatwoot-sdk';
 import { Chatwoot as ChatwootModel, Contact, Message } from '@prisma/client';
+import axios from 'axios';
 import { proto } from 'baileys';
 
 type ChatwootUser = {
@@ -93,8 +94,8 @@ class ChatwootImport {
         return 0;
       }
 
-      let contactsChunk: Contact[] = this.sliceIntoChunks(contacts, 3000);
-      while (contactsChunk.length > 0) {
+      const contactBatches = this.sliceIntoChunks(contacts, 3000);
+      for (const contactsChunk of contactBatches) {
         const labelSql = `SELECT id FROM labels WHERE title = '${provider.nameInbox}' AND account_id = ${provider.accountId} LIMIT 1`;
 
         let labelId = (await pgClient.query(labelSql))?.rows[0]?.id;
@@ -157,8 +158,6 @@ class ChatwootImport {
         }
 
         await pgClient.query(sqlInsertLabel, [tagId, 'Contact', 'labels']);
-
-        contactsChunk = this.sliceIntoChunks(contacts, 3000);
       }
 
       this.deleteHistoryContacts(instance);
@@ -206,6 +205,9 @@ class ChatwootImport {
     provider: ChatwootModel,
   ) {
     try {
+      this.logger.info(
+        `[importHistoryMessages] Iniciando importação de mensagens para a instância "${instance.instanceName}".`,
+      );
       const pgClient = postgresClient.getChatwootConnection();
 
       const chatwootUser = await this.getChatwootUser(provider);
@@ -213,31 +215,36 @@ class ChatwootImport {
         throw new Error('User not found to import messages.');
       }
 
+      const touchedConversations = new Set<string>();
       let totalMessagesImported = 0;
 
       let messagesOrdered = this.historyMessages.get(instance.instanceName) || [];
+      this.logger.info(
+        `[importHistoryMessages] Número de mensagens recuperadas do histórico: ${messagesOrdered.length}.`,
+      );
       if (messagesOrdered.length === 0) {
         return 0;
       }
 
-      // ordering messages by number and timestamp asc
+      // Ordenando as mensagens por remoteJid e timestamp (ascendente)
       messagesOrdered.sort((a, b) => {
-        const aKey = a.key as {
-          remoteJid: string;
-        };
-
-        const bKey = b.key as {
-          remoteJid: string;
-        };
+        const aKey = a.key as { remoteJid: string };
+        const bKey = b.key as { remoteJid: string };
 
         const aMessageTimestamp = a.messageTimestamp as any as number;
         const bMessageTimestamp = b.messageTimestamp as any as number;
 
         return parseInt(aKey.remoteJid) - parseInt(bKey.remoteJid) || aMessageTimestamp - bMessageTimestamp;
       });
+      this.logger.info('[importHistoryMessages] Mensagens ordenadas por remoteJid e messageTimestamp.');
 
+      // Mapeando mensagens por telefone
       const allMessagesMappedByPhoneNumber = this.createMessagesMapByPhoneNumber(messagesOrdered);
-      // Map structure: +552199999999 => { first message timestamp from number, last message timestamp from number}
+      this.logger.info(
+        `[importHistoryMessages] Mensagens mapeadas para ${allMessagesMappedByPhoneNumber.size} números únicos.`,
+      );
+
+      // Map: +numero => { first: timestamp, last: timestamp }
       const phoneNumbersWithTimestamp = new Map<string, firstLastTimestamp>();
       allMessagesMappedByPhoneNumber.forEach((messages: Message[], phoneNumber: string) => {
         phoneNumbersWithTimestamp.set(phoneNumber, {
@@ -245,15 +252,35 @@ class ChatwootImport {
           last: messages[messages.length - 1]?.messageTimestamp as any as number,
         });
       });
+      this.logger.info(
+        `[importHistoryMessages] Criado mapa de timestamps para ${phoneNumbersWithTimestamp.size} números.`,
+      );
 
+      // Removendo mensagens que já existem no banco (verificação pelo source_id)
       const existingSourceIds = await this.getExistingSourceIds(messagesOrdered.map((message: any) => message.key.id));
+      this.logger.info(
+        `[importHistoryMessages] Quantidade de source_ids existentes no banco: ${existingSourceIds.size}.`,
+      );
+      const initialCount = messagesOrdered.length;
       messagesOrdered = messagesOrdered.filter((message: any) => !existingSourceIds.has(message.key.id));
-      // processing messages in batch
+      this.logger.info(
+        `[importHistoryMessages] Mensagens filtradas: de ${initialCount} para ${messagesOrdered.length} após remoção de duplicados.`,
+      );
+
+      // Processamento das mensagens em batches
       const batchSize = 4000;
-      let messagesChunk: Message[] = this.sliceIntoChunks(messagesOrdered, batchSize);
-      while (messagesChunk.length > 0) {
-        // Map structure: +552199999999 => Message[]
+      const messagesChunks = this.sliceIntoChunks(messagesOrdered, batchSize);
+      let batchNumber = 1;
+      for (const messagesChunk of messagesChunks) {
+        this.logger.info(
+          `[importHistoryMessages] Processando batch ${batchNumber} com ${messagesChunk.length} mensagens.`,
+        );
+
+        // Agrupando as mensagens deste batch por telefone
         const messagesByPhoneNumber = this.createMessagesMapByPhoneNumber(messagesChunk);
+        this.logger.info(
+          `[importHistoryMessages] Batch ${batchNumber}: ${messagesByPhoneNumber.size} números únicos encontrados.`,
+        );
 
         if (messagesByPhoneNumber.size > 0) {
           const fksByNumber = await this.selectOrCreateFksFromChatwoot(
@@ -261,6 +288,12 @@ class ChatwootImport {
             inbox,
             phoneNumbersWithTimestamp,
             messagesByPhoneNumber,
+          );
+          for (const { conversation_id } of fksByNumber.values()) {
+            touchedConversations.add(conversation_id);
+          }
+          this.logger.info(
+            `[importHistoryMessages] Batch ${batchNumber}: FKs recuperados para ${fksByNumber.size} números.`,
           );
 
           // inserting messages in chatwoot db
@@ -271,6 +304,9 @@ class ChatwootImport {
 
           messagesByPhoneNumber.forEach((messages: any[], phoneNumber: string) => {
             const fksChatwoot = fksByNumber.get(phoneNumber);
+            this.logger.info(
+              `[importHistoryMessages] Número ${phoneNumber}: processando ${messages.length} mensagens.`,
+            );
 
             messages.forEach((message) => {
               if (!message.message) {
@@ -315,21 +351,39 @@ class ChatwootImport {
             if (sqlInsertMsg.slice(-1) === ',') {
               sqlInsertMsg = sqlInsertMsg.slice(0, -1);
             }
-            totalMessagesImported += (await pgClient.query(sqlInsertMsg, bindInsertMsg))?.rowCount ?? 0;
+            const result = await pgClient.query(sqlInsertMsg, bindInsertMsg);
+            const rowCount = result?.rowCount ?? 0;
+            totalMessagesImported += rowCount;
+            this.logger.info(`[importHistoryMessages] Batch ${batchNumber}: Inseridas ${rowCount} mensagens no banco.`);
           }
         }
-        messagesChunk = this.sliceIntoChunks(messagesOrdered, batchSize);
+        batchNumber++;
       }
 
       this.deleteHistoryMessages(instance);
       this.deleteRepositoryMessagesCache(instance);
+
+      this.logger.info(
+        `[importHistoryMessages] Histórico e cache de mensagens da instância "${instance.instanceName}" foram limpos.`,
+      );
+
+      for (const convId of touchedConversations) {
+        await this.safeRefreshConversation(provider.url, provider.accountId, convId, provider.token);
+      }
 
       const providerData: ChatwootDto = {
         ...provider,
         ignoreJids: Array.isArray(provider.ignoreJids) ? provider.ignoreJids.map((event) => String(event)) : [],
       };
 
-      this.importHistoryContacts(instance, providerData);
+      this.logger.info(
+        `[importHistoryMessages] Iniciando importação de contatos do histórico para a instância "${instance.instanceName}".`,
+      );
+      await this.importHistoryContacts(instance, providerData);
+
+      this.logger.info(
+        `[importHistoryMessages] Concluída a importação de mensagens para a instância "${instance.instanceName}". Total importado: ${totalMessagesImported}.`,
+      );
 
       return totalMessagesImported;
     } catch (error) {
@@ -340,6 +394,24 @@ class ChatwootImport {
     }
   }
 
+  private normalizeBrazilianPhoneNumberOptions(raw: string): [string, string] {
+    if (!raw.startsWith('+55')) {
+      return [raw, raw];
+    }
+
+    const digits = raw.slice(3);
+
+    if (digits.length === 10) {
+      const newDigits = digits.slice(0, 2) + '9' + digits.slice(2);
+      return [raw, `+55${newDigits}`];
+    } else if (digits.length === 11) {
+      const oldDigits = digits.slice(0, 2) + digits.slice(3);
+      return [`+55${oldDigits}`, raw];
+    } else {
+      return [raw, raw];
+    }
+  }
+
   public async selectOrCreateFksFromChatwoot(
     provider: ChatwootModel,
     inbox: inbox,
@@ -347,89 +419,144 @@ class ChatwootImport {
     messagesByPhoneNumber: Map<string, Message[]>,
   ): Promise<Map<string, FksChatwoot>> {
     const pgClient = postgresClient.getChatwootConnection();
+    const resultMap = new Map<string, FksChatwoot>();
 
-    const bindValues = [provider.accountId, inbox.id];
-    const phoneNumberBind = Array.from(messagesByPhoneNumber.keys())
-      .map((phoneNumber) => {
-        const phoneNumberTimestamp = phoneNumbersWithTimestamp.get(phoneNumber);
+    for (const rawPhone of messagesByPhoneNumber.keys()) {
+      // 1) Normalizar telefone e gerar JIDs
+      const [normalizedWith, normalizedWithout] = this.normalizeBrazilianPhoneNumberOptions(rawPhone);
+      const jidWith = normalizedWith.replace(/^\+/, '') + '@s.whatsapp.net';
+      const jidWithout = normalizedWithout.replace(/^\+/, '') + '@s.whatsapp.net';
 
-        if (phoneNumberTimestamp) {
-          bindValues.push(phoneNumber);
-          let bindStr = `($${bindValues.length},`;
+      const ts = phoneNumbersWithTimestamp.get(rawPhone);
+      if (!ts) {
+        this.logger.warn(`Timestamp não encontrado para ${rawPhone}`);
+        throw new Error(`Timestamp não encontrado para ${rawPhone}`);
+      }
 
-          bindValues.push(phoneNumberTimestamp.first);
-          bindStr += `$${bindValues.length},`;
+      // 2) Buscar ou inserir Contact (agora incluindo identifier)
+      let contact: { id: number; phone_number: string };
+      {
+        const selectContact = `
+          SELECT id, phone_number
+            FROM contacts
+           WHERE account_id = $1
+             AND (
+               phone_number = $2
+               OR phone_number = $3
+               OR identifier   = $4
+               OR identifier   = $5
+             )
+           LIMIT 1
+        `;
+        const res = await pgClient.query(selectContact, [
+          provider.accountId,
+          normalizedWith,
+          normalizedWithout,
+          jidWith,
+          jidWithout,
+        ]);
+        if (res.rowCount) {
+          contact = res.rows[0];
+          this.logger.verbose(`Contato existente: ${JSON.stringify(contact)}`);
+        } else {
+          const insertContact = `
+          INSERT INTO contacts
+            (name, phone_number, account_id, identifier, created_at, updated_at)
+          VALUES
+            (
+              REPLACE($2, '+', ''),
+              $2,
+              $1,
+              $5,
+              to_timestamp($3),
+              to_timestamp($4)
+            )
+          RETURNING id, phone_number
+        `;
+          const insertRes = await pgClient.query(insertContact, [
+            provider.accountId,
+            normalizedWith,
+            ts.first,
+            ts.last,
+            jidWith,
+          ]);
+          contact = insertRes.rows[0];
 
-          bindValues.push(phoneNumberTimestamp.last);
-          return `${bindStr}$${bindValues.length})`;
+          this.logger.verbose(`Contato inserido: ${JSON.stringify(contact)}`);
         }
-      })
-      .join(',');
+      }
 
-    // select (or insert when necessary) data from tables contacts, contact_inboxes, conversations from chatwoot db
-    const sqlFromChatwoot = `WITH
-              phone_number AS (
-                SELECT phone_number, created_at::INTEGER, last_activity_at::INTEGER FROM (
-                  VALUES 
-                   ${phoneNumberBind}
-                 ) as t (phone_number, created_at, last_activity_at)
-              ),
+      // 3) Buscar ou inserir ContactInbox
+      let contactInboxId: number;
+      {
+        const selectCi = `
+          SELECT id
+            FROM contact_inboxes
+           WHERE contact_id = $1
+             AND inbox_id   = $2
+           LIMIT 1
+        `;
+        const ciRes = await pgClient.query(selectCi, [contact.id, inbox.id]);
+        if (ciRes.rowCount) {
+          contactInboxId = ciRes.rows[0].id;
+          this.logger.verbose(`Contact_inbox existente: ${contactInboxId}`);
+        } else {
+          const insertCi = `
+            INSERT INTO contact_inboxes
+              (contact_id, inbox_id, source_id, created_at, updated_at)
+            VALUES
+              ($1, $2, gen_random_uuid(), NOW(), NOW())
+            RETURNING id
+          `;
+          const insertRes = await pgClient.query(insertCi, [contact.id, inbox.id]);
+          contactInboxId = insertRes.rows[0].id;
+          this.logger.verbose(`Contact_inbox inserido: ${contactInboxId}`);
+        }
+      }
 
-              only_new_phone_number AS (
-                SELECT * FROM phone_number
-                WHERE phone_number NOT IN (
-                  SELECT phone_number
-                  FROM contacts
-                    JOIN contact_inboxes ci ON ci.contact_id = contacts.id AND ci.inbox_id = $2
-                    JOIN conversations con ON con.contact_inbox_id = ci.id 
-                      AND con.account_id = $1
-                      AND con.inbox_id = $2
-                      AND con.contact_id = contacts.id
-                  WHERE contacts.account_id = $1
-                )
-              ),
+      // 4) Buscar ou inserir Conversation
+      let conversationId: number;
+      {
+        const selectConv = `
+          SELECT id
+            FROM conversations
+           WHERE account_id = $1
+             AND inbox_id   = $2
+             AND contact_id = $3
+           LIMIT 1
+        `;
+        const convRes = await pgClient.query(selectConv, [provider.accountId, inbox.id, contact.id]);
+        if (convRes.rowCount) {
+          conversationId = convRes.rows[0].id;
+          this.logger.verbose(`Conversa existente: ${conversationId}`);
+        } else {
+          const insertConv = `
+            INSERT INTO conversations
+              (account_id, inbox_id, status, contact_id, contact_inbox_id, uuid,
+               last_activity_at, created_at, updated_at)
+            VALUES
+              ($1, $2, 0, $3, $4, gen_random_uuid(), NOW(), NOW(), NOW())
+            RETURNING id
+          `;
+          const insertRes = await pgClient.query(insertConv, [
+            provider.accountId,
+            inbox.id,
+            contact.id,
+            contactInboxId,
+          ]);
+          conversationId = insertRes.rows[0].id;
+          this.logger.verbose(`Conversa inserida: ${conversationId}`);
+        }
+      }
 
-              new_contact AS (
-                INSERT INTO contacts (name, phone_number, account_id, identifier, created_at, updated_at)
-                SELECT REPLACE(p.phone_number, '+', ''), p.phone_number, $1, CONCAT(REPLACE(p.phone_number, '+', ''),
-                  '@s.whatsapp.net'), to_timestamp(p.created_at), to_timestamp(p.last_activity_at)
-                FROM only_new_phone_number AS p
-                ON CONFLICT(identifier, account_id) DO UPDATE SET updated_at = EXCLUDED.updated_at
-                RETURNING id, phone_number, created_at, updated_at
-              ),
+      resultMap.set(rawPhone, {
+        phone_number: normalizedWith,
+        contact_id: String(contact.id),
+        conversation_id: String(conversationId),
+      });
+    }
 
-              new_contact_inbox AS (
-                INSERT INTO contact_inboxes (contact_id, inbox_id, source_id, created_at, updated_at)
-                SELECT new_contact.id, $2, gen_random_uuid(), new_contact.created_at, new_contact.updated_at
-                FROM new_contact 
-                RETURNING id, contact_id, created_at, updated_at
-              ),
-
-              new_conversation AS (
-                INSERT INTO conversations (account_id, inbox_id, status, contact_id,
-                  contact_inbox_id, uuid, last_activity_at, created_at, updated_at)
-                SELECT $1, $2, 0, new_contact_inbox.contact_id, new_contact_inbox.id, gen_random_uuid(),
-                  new_contact_inbox.updated_at, new_contact_inbox.created_at, new_contact_inbox.updated_at
-                FROM new_contact_inbox
-                RETURNING id, contact_id
-              )
-
-              SELECT new_contact.phone_number, new_conversation.contact_id, new_conversation.id AS conversation_id
-              FROM new_conversation 
-              JOIN new_contact ON new_conversation.contact_id = new_contact.id
-
-              UNION
-
-              SELECT p.phone_number, c.id contact_id, con.id conversation_id
-                FROM phone_number p
-              JOIN contacts c ON c.phone_number = p.phone_number
-              JOIN contact_inboxes ci ON ci.contact_id = c.id AND ci.inbox_id = $2
-              JOIN conversations con ON con.contact_inbox_id = ci.id AND con.account_id = $1
-                AND con.inbox_id = $2 AND con.contact_id = c.id`;
-
-    const fksFromChatwoot = await pgClient.query(sqlFromChatwoot, bindValues);
-
-    return new Map(fksFromChatwoot.rows.map((item: FksChatwoot) => [item.phone_number, item]));
+    return resultMap;
   }
 
   public async getChatwootUser(provider: ChatwootModel): Promise<ChatwootUser> {
@@ -548,8 +675,12 @@ class ChatwootImport {
     }
   }
 
-  public sliceIntoChunks(arr: any[], chunkSize: number) {
-    return arr.splice(0, chunkSize);
+  public sliceIntoChunks<T>(arr: T[], chunkSize: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < arr.length; i += chunkSize) {
+      chunks.push(arr.slice(i, i + chunkSize));
+    }
+    return chunks;
   }
 
   public isGroup(remoteJid: string) {
@@ -566,6 +697,37 @@ class ChatwootImport {
     const sql = `UPDATE messages SET source_id = $1, status = 0, created_at = NOW(), updated_at = NOW() WHERE id = $2;`;
 
     return pgClient.query(sql, [`WAID:${sourceId}`, messageId]);
+  }
+
+  private async safeRefreshConversation(
+    providerUrl: string,
+    accountId: string,
+    conversationId: string,
+    apiToken: string,
+  ): Promise<void> {
+    try {
+      const pgClient = postgresClient.getChatwootConnection();
+      const res = await pgClient.query(
+        `SELECT display_id
+           FROM conversations
+          WHERE id = $1
+          LIMIT 1`,
+        [parseInt(conversationId, 10)],
+      );
+      const displayId = res.rows[0]?.display_id as string;
+      if (!displayId) {
+        this.logger.warn(`Conversation ${conversationId} sem display_id.`);
+        return;
+      }
+
+      const url = `${providerUrl}/api/v1/accounts/${accountId}/conversations/${displayId}/refresh`;
+      await axios.post(url, null, {
+        params: { api_access_token: apiToken },
+      });
+      this.logger.verbose(`Conversa ${displayId} refreshada com sucesso.`);
+    } catch (err: any) {
+      this.logger.warn(`Não foi possível dar refresh na conversa ${conversationId}: ${err.message}`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- enhance chatwoot import helper for message history
- normalize brazilian phone numbers
- add safe refresh of conversations
- provide more detailed logging
- support returning chunk arrays when slicing

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module './test/all.test.ts')*

------
https://chatgpt.com/codex/tasks/task_b_6872970fd74c8327854b2839d54a930a