### PR TITLE
Fix npm install with peer deps conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /evolution
 
 COPY ./package.json ./tsconfig.json ./
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 COPY ./src ./src
 COPY ./public ./public

--- a/local_install.sh
+++ b/local_install.sh
@@ -72,7 +72,7 @@ npm_install_with_retry() {
     
     while [ $attempt -le $max_attempts ]; do
         log "Tentativa $attempt de $max_attempts para npm install"
-        if npm install; then
+        if npm install --legacy-peer-deps; then
             return 0
         fi
         attempt=$((attempt + 1))
@@ -119,7 +119,7 @@ log "npm: $(npm -v)"
 # Instala dependências do projeto
 log "Instalando dependências do projeto..."
 rm -rf node_modules
-npm install
+npm install --legacy-peer-deps
 
 # Deploy do banco de dados
 log "Deploy do banco de dados..."


### PR DESCRIPTION
## Summary
- ignore peer dependency conflicts during npm install in Dockerfile and script

## Testing
- `npm test` *(fails: Cannot find module './test/all.test.ts')*


------
https://chatgpt.com/codex/tasks/task_b_6872b5f410fc8327b6d8301bc01d5b95