### PR TITLE
Add warning for messages without key id

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1365,6 +1365,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
       for await (const { key, update } of args) {
         if (!key.id) {
+          console.warn(`Mensagem sem key.id, pulando update: ${JSON.stringify(key)}`);
           continue;
         }
 


### PR DESCRIPTION
## Summary
- warn when `messages.update` entries have missing `key.id`

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: tsnd not found)*

------
https://chatgpt.com/codex/tasks/task_b_6872b95de4048327a9aeeb8830834a0c