### PR TITLE
Update Chatwoot pending conv logic

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -45,7 +45,7 @@ export class ChatwootService {
 
   private provider: any;
 
-  private pendingCreateConv = new Map<string, Promise<number | null>>();
+  private pendingCreateConv = new Map<string, Promise<number>>();
 
   constructor(
     private readonly waMonitor: WAMonitoringService,
@@ -812,7 +812,7 @@ export class ChatwootService {
     let triedRecovery = false;
     const cacheKey = `${instance.instanceName}:createConversation-${remoteJid}`;
 
-    const promise = (async (): Promise<number | null> => {
+    const promise = (async (): Promise<number> => {
       try {
         return await this._createConversation(instance, body);
       } catch (err) {
@@ -831,6 +831,7 @@ export class ChatwootService {
       return await promise;
     } finally {
       this.pendingCreateConv.delete(remoteJid);
+      this.logger.verbose(`[createConversation] Removido pendingCreateConv para ${remoteJid}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- narrow Chatwoot pending conversation cache type
- log when clearing a pending conversation

## Testing
- `npx eslint --config .eslintrc.js --ext .ts src` *(fails: A config object is using the "parser" key, which is not supported in flat config system.)*
- `npx tsc --noEmit` *(fails to compile due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6872b9af71f08327964dbc04f8bbc6af