### PR TITLE
Fix Jimp import and bucket logging

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -26,7 +26,7 @@ import axios from 'axios';
 import { proto } from 'baileys';
 import dayjs from 'dayjs';
 import FormData from 'form-data';
-import Jimp from 'jimp';
+import { Jimp, JimpMime } from 'jimp';
 import Long from 'long';
 import mimeTypes from 'mime-types';
 import path from 'path';
@@ -2156,7 +2156,7 @@ export class ChatwootService {
           const img = await Jimp.read(fileData);
           await img.cover(320, 180);
 
-          const processedBuffer = await img.getBufferAsync(Jimp.MIME_PNG);
+          const processedBuffer = await img.getBufferAsync(JimpMime.png);
 
           const fileStream = new Readable();
           fileStream._read = () => {}; // _read is required but you can noop it

--- a/src/api/integrations/storage/s3/libs/minio.server.ts
+++ b/src/api/integrations/storage/s3/libs/minio.server.ts
@@ -61,7 +61,7 @@ const setBucketPolicy = async () => {
     if (err.code === 'NotImplemented') {
       logger.warn(`[S3 Service] setBucketPolicy not supported by this endpoint, ignoring (bucket=${bucketName})`);
     } else {
-      logger.error('[S3 Service] Error applying bucket policy', err);
+      logger.error(['[S3 Service] Error applying bucket policy', err]);
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- update Jimp import to match library exports
- log S3 bucket policy errors with a single argument

## Testing
- `npm run build` *(fails: Cannot find module 'baileys')*

------
https://chatgpt.com/codex/tasks/task_b_6872cdbb0a8c83278feb1abea2e18727