### PR TITLE
Fix Jimp type usage

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -2101,9 +2101,9 @@ export class ChatwootService {
           const fileData = Buffer.from(imgBuffer.data, 'binary');
 
           const img = await Jimp.read(fileData);
-          await img.cover(320, 180);
+          await (img as any).cover(320, 180);
 
-          const processedBuffer = await img.getBufferAsync(Jimp.MIME_PNG);
+          const processedBuffer = await (img as any).getBufferAsync(Jimp.MIME_PNG);
 
           const fileStream = new Readable();
           fileStream._read = () => {}; // _read is required but you can noop it


### PR DESCRIPTION
## Summary
- fix Jimp typings in chatwoot service to remove TS errors

## Testing
- `npm run build` *(fails: Cannot find module 'baileys', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6872d15f7b388327b6eaf9c9697111df