### PR TITLE
Fix Jimp API usage for advertisement thumbnails

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -2154,9 +2154,9 @@ export class ChatwootService {
           const fileData = Buffer.from(imgBuffer.data, 'binary');
 
           const img = await Jimp.read(fileData);
-          await img.cover(320, 180);
+          await img.cover({ w: 320, h: 180 });
 
-          const processedBuffer = await img.getBufferAsync(JimpMime.png);
+          const processedBuffer = await img.getBuffer(JimpMime.png);
 
           const fileStream = new Readable();
           fileStream._read = () => {}; // _read is required but you can noop it


### PR DESCRIPTION
## Summary
- update `cover` usage to use new options object
- use `getBuffer` instead of removed `getBufferAsync`

## Testing
- `npm run build` *(fails: Module '@prisma/client' has no exported member ...)*
- `npm test` *(fails: Cannot find module './test/all.test.ts')*

------
https://chatgpt.com/codex/tasks/task_b_6872e59a82f08327872bbd0c4f3962c0