### PR TITLE
Revert jimp version to 0.16.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11873,7 +11873,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary
- restore jimp dependency to `^0.16.13` in package.json
- regenerate package-lock.json to match

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Cannot find module './test/all.test.ts')*

------
https://chatgpt.com/codex/tasks/task_b_687320ea924c8327a461aad2dcee7c6a